### PR TITLE
feat + refactor: markdown support, image and video

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.zaffox.discordwear"
+        applicationId "com.bway.discordwear"
         minSdk 30
         targetSdk 35
         versionCode 7

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.bway.discordwear"
+        applicationId "com.zaffox.discordwear"
         minSdk 30
         targetSdk 35
         versionCode 7
@@ -57,6 +57,7 @@ android {
         release {
             signingConfig signingConfigs.release
             minifyEnabled true
+            shrinkResources true
         }
     }
 }

--- a/app/src/main/kotlin/com/zaffox/DiscordWear/api/Models.kt
+++ b/app/src/main/kotlin/com/zaffox/DiscordWear/api/Models.kt
@@ -466,7 +466,8 @@ object ContentParser {
         val italic: Boolean = false,
         val strikethrough: Boolean = false,
         val code: Boolean = false,
-        val spoiler: Boolean = false
+        val spoiler: Boolean = false,
+        val subtext: Boolean  = false
     )
 
     fun parseMarkdown(text: String): List<MarkdownSpan> {
@@ -478,7 +479,8 @@ object ContentParser {
             """|(~~(.+?)~~)""" +
             """|(```.+?```)|(`(.+?)`)""" +
             """|(\|\|(.+?)\|\|)""" +
-            """|(_{2}(.+?)_{2})""",
+            """|(_{2}(.+?)_{2})""" +
+                    """|(^\-#\s+(.+)$)""",
             setOf(RegexOption.DOT_MATCHES_ALL)
         )
         var cursor = 0
@@ -495,6 +497,7 @@ object ContentParser {
                 raw.startsWith("`") -> spans += MarkdownSpan(match.groupValues[9], code = true)
                 raw.startsWith("||") -> spans += MarkdownSpan(match.groupValues[11], spoiler = true)
                 raw.startsWith("__") -> spans += MarkdownSpan(match.groupValues[13], bold = true)
+                raw.startsWith("-#") -> spans += MarkdownSpan(match.groupValues[15], subtext = true)
                 else -> spans += MarkdownSpan(raw)
             }
             cursor = match.range.last + 1

--- a/app/src/main/kotlin/com/zaffox/DiscordWear/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/zaffox/DiscordWear/screens/ChatScreen.kt
@@ -191,8 +191,7 @@ fun ChatScreen(
 
     fun startRecording() {
         val hasAudio = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.RECORD_AUDIO
+            context, Manifest.permission.RECORD_AUDIO
         ) == PackageManager.PERMISSION_GRANTED
         if (!hasAudio) {
             micPermLauncher.launch(Manifest.permission.RECORD_AUDIO); return
@@ -293,8 +292,8 @@ fun ChatScreen(
                         mime.contains("webp") -> "webp"
                         else -> "jpg"
                     }
-                    val bytes = cr.openInputStream(uri)?.readBytes()
-                        ?: throw Exception("Cannot read image")
+                    val bytes =
+                        cr.openInputStream(uri)?.readBytes() ?: throw Exception("Cannot read image")
                     repo.sendFileAttachment(channelId, bytes, "image.$ext", mime)
                         .onFailure { uploadError = "Upload failed: ${it.message}" }
                 }.onFailure { uploadError = "Error: ${it.message}" }
@@ -588,8 +587,7 @@ fun ChatScreen(
 
                         val isContinuation =
                             prevMsg != null && prevMsg.author.id == msg.author.id && msg.type !in listOf(
-                                19,
-                                23
+                                19, 23
                             ) && prevMsg.type !in listOf(19, 23) && gapMs < 10 * 60 * 1000L
 
                         MessageBubble(
@@ -816,8 +814,7 @@ fun ChatScreen(
                                                 if (android.os.Build.VERSION.SDK_INT >= 33) Manifest.permission.READ_MEDIA_IMAGES
                                                 else Manifest.permission.READ_EXTERNAL_STORAGE
                                             val hasPerm = ContextCompat.checkSelfPermission(
-                                                context,
-                                                perm
+                                                context, perm
                                             ) == PackageManager.PERMISSION_GRANTED
                                             if (hasPerm) {
                                                 showPhotoPicker = true
@@ -1358,25 +1355,9 @@ private fun MessageBubble(
             }
 
             msg.attachments.filter { it.isImage }.forEach { att ->
-                MessageContent(
-                    content = att.proxyUrl,
-                    imageLoader = imageLoader,
-                    context = context,
-                    userNames = userNames,
-                    channelNames = channelNames,
-                    spoilerRevealOnTap = spoilerRevealOnTap
-                )
                 MediaImage(att.proxyUrl, att.filename, imageLoader)
             }
             msg.attachments.filter { it.isVideo }.forEach { att ->
-                MessageContent(
-                    content = att.proxyUrl,
-                    imageLoader = imageLoader,
-                    context = context,
-                    userNames = userNames,
-                    channelNames = channelNames,
-                    spoilerRevealOnTap = spoilerRevealOnTap
-                )
                 VideoAttachment(att, imageLoader)
             }
             msg.attachments.filter { it.isAudio }.forEach { att ->
@@ -1506,8 +1487,7 @@ private fun MessageContent(
                         modifier = Modifier.clickable {
                             runCatching {
                                 val intent = Intent(
-                                    Intent.ACTION_VIEW,
-                                    Uri.parse(part.url)
+                                    Intent.ACTION_VIEW, Uri.parse(part.url)
                                 ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                                 context.startActivity(intent)
                             }
@@ -1564,6 +1544,7 @@ private fun ReactionChip(reaction: Reaction, imageLoader: ImageLoader, onClick: 
 private fun MediaImage(
     url: String, contentDesc: String, imageLoader: ImageLoader, size: Dp = 120.dp
 ) {
+    val context = LocalContext.current
     AsyncImage(
         model = ImageRequest.Builder(LocalContext.current).data(url).crossfade(true).build(),
         imageLoader = imageLoader,
@@ -1573,7 +1554,14 @@ private fun MediaImage(
             .padding(top = 2.dp)
             .widthIn(max = size)
             .heightIn(max = size)
-    )
+            .clickable {
+                runCatching {
+                    val intent = Intent(
+                        Intent.ACTION_VIEW, Uri.parse(url)
+                    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    context.startActivity(intent)
+                }
+            })
 }
 
 @Composable
@@ -1630,8 +1618,7 @@ private fun EmbedCard(embed: Embed, imageLoader: ImageLoader) {
     val imgUrl = embed.displayImageUrl
     if (imgUrl != null) {
         AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current).data(imgUrl).crossfade(true)
-                .build(),
+            model = ImageRequest.Builder(LocalContext.current).data(imgUrl).crossfade(true).build(),
             imageLoader = imageLoader,
             contentDescription = embed.title ?: "embed",
             contentScale = ContentScale.Fit,
@@ -1646,6 +1633,8 @@ private fun EmbedCard(embed: Embed, imageLoader: ImageLoader) {
 @Composable
 private fun VideoAttachment(att: Attachment, imageLoader: ImageLoader) {
     val context = LocalContext.current
+    val encodedVideoLink = Uri.encode(att.proxyUrl)
+    val VideoURL = "https://bway.lol/internal/video?video_link=$encodedVideoLink"
     Box(
         modifier = Modifier
             .padding(top = 2.dp)
@@ -1654,9 +1643,8 @@ private fun VideoAttachment(att: Attachment, imageLoader: ImageLoader) {
             .clickable {
                 runCatching {
                     val intent = Intent(
-                        Intent.ACTION_VIEW, Uri.parse(att.url)
-                    ).setDataAndType(Uri.parse(att.url), att.contentType ?: "video/*")
-                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        Intent.ACTION_VIEW, Uri.parse(VideoURL)
+                    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     context.startActivity(intent)
                 }
             }) {

--- a/app/src/main/kotlin/com/zaffox/DiscordWear/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/zaffox/DiscordWear/screens/ChatScreen.kt
@@ -788,6 +788,18 @@ fun ChatScreen(
                                 contentDescription = "Voice Message"
                             )
                         }
+
+                        FilledIconButton(
+                            onClick = { inputText += "||"; },
+                            modifier = Modifier
+                                .width(40.dp)
+                                .height(40.dp)
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.spoiler),
+                                contentDescription = "Text Spoiler"
+                            )
+                        }
                     }
                 } else {
                     Column(
@@ -1264,9 +1276,25 @@ private fun MessageBubble(
             }
 
             msg.attachments.filter { it.isImage }.forEach { att ->
+                MessageContent(
+                    content = att.proxyUrl,
+                    imageLoader = imageLoader,
+                    context = context,
+                    userNames = userNames,
+                    channelNames = channelNames,
+                    spoilerRevealOnTap = spoilerRevealOnTap
+                )
                 MediaImage(att.proxyUrl, att.filename, imageLoader)
             }
             msg.attachments.filter { it.isVideo }.forEach { att ->
+                MessageContent(
+                    content = att.proxyUrl,
+                    imageLoader = imageLoader,
+                    context = context,
+                    userNames = userNames,
+                    channelNames = channelNames,
+                    spoilerRevealOnTap = spoilerRevealOnTap
+                )
                 VideoAttachment(att, imageLoader)
             }
             msg.attachments.filter { it.isAudio }.forEach { att ->

--- a/app/src/main/kotlin/com/zaffox/DiscordWear/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/zaffox/DiscordWear/screens/ChatScreen.kt
@@ -48,6 +48,7 @@ import android.media.MediaPlayer
 import android.media.MediaRecorder
 import android.Manifest
 import android.content.pm.PackageManager
+import androidx.compose.foundation.border
 import androidx.core.content.ContextCompat
 import com.zaffox.discordwear.api.*
 import com.zaffox.discordwear.discordApp
@@ -56,6 +57,8 @@ import com.zaffox.discordwear.R
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
 import java.io.File
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -73,13 +76,10 @@ fun ChatScreen(
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
     val imageLoader = remember {
-        ImageLoader.Builder(context)
-            .components {
-                if (android.os.Build.VERSION.SDK_INT >= 28)
-                    add(ImageDecoderDecoder.Factory())
-                else
-                    add(GifDecoder.Factory())
-            }.build()
+        ImageLoader.Builder(context).components {
+            if (android.os.Build.VERSION.SDK_INT >= 28) add(ImageDecoderDecoder.Factory())
+            else add(GifDecoder.Factory())
+        }.build()
     }
 
     val allMessages by (repo?.messages ?: return).collectAsState()
@@ -101,10 +101,7 @@ fun ChatScreen(
     // Pre-load role data for all visible authors once messages load (guild channels only)
     LaunchedEffect(messages, guildId, loading) {
         if (!loading && guildId != null) {
-            messages
-                .map { it.author.id }
-                .distinct()
-                .filterNot { roleColorCache.containsKey(it) }
+            messages.map { it.author.id }.distinct().filterNot { roleColorCache.containsKey(it) }
                 .forEach { userId ->
                     roleColorCache[userId] = repo?.getTopRoleForUser(guildId, userId)
                 }
@@ -121,7 +118,7 @@ fun ChatScreen(
     val compactMode = remember { SetupPreferences.getCompactMode(context) }
     val slowModeSecs = remember(channelId) { repo.getSlowModeSeconds(channelId) }
     var slowRemaining by remember { mutableStateOf(0) }
-    
+
     LaunchedEffect(slowModeSecs) {
         if (slowModeSecs > 0) {
             while (true) {
@@ -153,6 +150,7 @@ fun ChatScreen(
                     lastReadIdx >= 0 -> {
                         scope.launch { listState.animateScrollToItem(lastReadIdx + 1) }
                     }
+
                     else -> {
                         scope.launch { listState.animateScrollToItem(1) }
                     }
@@ -192,9 +190,13 @@ fun ChatScreen(
     }
 
     fun startRecording() {
-        val hasAudio = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
-            PackageManager.PERMISSION_GRANTED
-        if (!hasAudio) { micPermLauncher.launch(Manifest.permission.RECORD_AUDIO); return }
+        val hasAudio = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.RECORD_AUDIO
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!hasAudio) {
+            micPermLauncher.launch(Manifest.permission.RECORD_AUDIO); return
+        }
         try {
             val f = File(context.cacheDir, "voice_${System.currentTimeMillis()}.ogg")
             voiceFile = f
@@ -221,7 +223,8 @@ fun ChatScreen(
         try {
             mr.stop()
             mr.release()
-        } catch (_: Exception) {}
+        } catch (_: Exception) {
+        }
         recorder = null
         isRecording = false
         scope.launch {
@@ -236,7 +239,10 @@ fun ChatScreen(
 
     fun cancelRecording() {
         val mr = recorder ?: return
-        try { mr.stop(); mr.release() } catch (_: Exception) {}
+        try {
+            mr.stop(); mr.release()
+        } catch (_: Exception) {
+        }
         recorder = null
         isRecording = false
         voiceFile?.delete()
@@ -248,7 +254,9 @@ fun ChatScreen(
             while (isRecording) {
                 delay(1_000)
                 recordingSecs++
-                if (recordingSecs >= 120) { stopAndSendRecording(); break }
+                if (recordingSecs >= 120) {
+                    stopAndSendRecording(); break
+                }
             }
         }
     }
@@ -274,28 +282,24 @@ fun ChatScreen(
     }
 
     if (showPhotoPicker) {
-        PhotoPickerScreen(
-            imageLoader = imageLoader,
-            onImageSelected = { uri, mime ->
-                showPhotoPicker = false
-                scope.launch {
-                    runCatching {
-                        val cr = context.contentResolver
-                        val ext = when {
-                            mime.contains("png") -> "png"
-                            mime.contains("gif") -> "gif"
-                            mime.contains("webp") -> "webp"
-                            else -> "jpg"
-                        }
-                        val bytes = cr.openInputStream(uri)?.readBytes()
-                            ?: throw Exception("Cannot read image")
-                        repo.sendFileAttachment(channelId, bytes, "image.$ext", mime)
-                            .onFailure { uploadError = "Upload failed: ${it.message}" }
-                    }.onFailure { uploadError = "Error: ${it.message}" }
-                }
-            },
-            onDismiss = { showPhotoPicker = false }
-        )
+        PhotoPickerScreen(imageLoader = imageLoader, onImageSelected = { uri, mime ->
+            showPhotoPicker = false
+            scope.launch {
+                runCatching {
+                    val cr = context.contentResolver
+                    val ext = when {
+                        mime.contains("png") -> "png"
+                        mime.contains("gif") -> "gif"
+                        mime.contains("webp") -> "webp"
+                        else -> "jpg"
+                    }
+                    val bytes = cr.openInputStream(uri)?.readBytes()
+                        ?: throw Exception("Cannot read image")
+                    repo.sendFileAttachment(channelId, bytes, "image.$ext", mime)
+                        .onFailure { uploadError = "Upload failed: ${it.message}" }
+                }.onFailure { uploadError = "Error: ${it.message}" }
+            }
+        }, onDismiss = { showPhotoPicker = false })
         return
     }
 
@@ -306,8 +310,7 @@ fun ChatScreen(
             ScalingLazyColumn(state = editListState, modifier = Modifier.fillMaxSize()) {
                 item {
                     Text(
-                        "Edit message",
-                        style = MaterialTheme.typography.titleSmall
+                        "Edit message", style = MaterialTheme.typography.titleSmall
                     )
                 }
                 item {
@@ -315,7 +318,11 @@ fun ChatScreen(
                         value = editText,
                         onValueChange = { editText = it },
                         modifier = Modifier.fillMaxWidth(),
-                        label = { Text("Edit", color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                        label = {
+                            Text(
+                                "Edit", color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        },
                         textStyle = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.onSurface),
                         colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
                             focusedTextColor = MaterialTheme.colorScheme.onSurface,
@@ -344,14 +351,18 @@ fun ChatScreen(
                                     }
                                 }
                             },
-                            modifier = Modifier.weight(1f).height(36.dp),
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(36.dp),
                             colors = ButtonDefaults.filledTonalButtonColors(),
                             enabled = editText.isNotBlank()
                         ) { Text("Save") }
                         Spacer(Modifier.width(8.dp))
                         Button(
                             onClick = { editingMsg = null; editText = "" },
-                            modifier = Modifier.weight(1f).height(36.dp),
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(36.dp),
                             colors = ButtonDefaults.outlinedButtonColors()
                         ) { Text("Cancel") }
                     }
@@ -364,7 +375,7 @@ fun ChatScreen(
     if (showPicker) {
         val isReactMode = reactingToMsg != null
         EmojiStickerScreen(
-            tab = if (isReactMode) 0 else tab, 
+            tab = if (isReactMode) 0 else tab,
             guildId = guildId,
             hasNitro = hasNitro,
             sendAnimatedAsGif = sendAnimatedAsGif,
@@ -387,14 +398,15 @@ fun ChatScreen(
                 } else {
                     val isAnimated = insertText.startsWith("<a:")
                     if (isAnimated && sendAnimatedAsGif) {
-                       showPicker = false
+                        showPicker = false
                         val link = buildEmojiLink(insertText)
                         scope.launch {
                             repo.sendMessage(channelId, link)
                                 .onFailure { sendError = "Failed: ${it.message}" }
                         }
                     } else {
-                        val newText = if (inputText.isBlank()) insertText else "$inputText$insertText"
+                        val newText =
+                            if (inputText.isBlank()) insertText else "$inputText$insertText"
                         inputText = newText
                         pendingText = newText
                     }
@@ -406,8 +418,11 @@ fun ChatScreen(
                 if (target != null) {
                     val reactionEmoji = ReactionEmoji(id = null, name = unicode, animated = false)
                     scope.launch {
-                        try { repo.toggleReaction(channelId, target.id, reactionEmoji) }
-                        catch (e: Exception) { sendError = "Failed: ${e.message}" }
+                        try {
+                            repo.toggleReaction(channelId, target.id, reactionEmoji)
+                        } catch (e: Exception) {
+                            sendError = "Failed: ${e.message}"
+                        }
                     }
                     reactingToMsg = null
                 } else {
@@ -423,15 +438,14 @@ fun ChatScreen(
                     try {
                         repo.sendSticker(channelId, stickerId)
                     } catch (e: Exception) {
-                       sendError = "Failed: ${e.message}"
+                        sendError = "Failed: ${e.message}"
                     }
                 }
-            }
-        )
+            })
         return
     }
 
-   val msgForOptions = selectedMsg
+    val msgForOptions = selectedMsg
     if (msgForOptions != null) {
         MessageOptionsDialog(
             msg = msgForOptions,
@@ -441,8 +455,8 @@ fun ChatScreen(
                 selectedMsg = null
             },
             onCopy = {
-                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
-                    as android.content.ClipboardManager
+                val clipboard =
+                    context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
                 clipboard.setPrimaryClip(
                     android.content.ClipData.newPlainText("message", msgForOptions.content)
                 )
@@ -464,8 +478,7 @@ fun ChatScreen(
                 selectedMsg = null
                 showPicker = true
             },
-            onDismiss = { selectedMsg = null }
-        )
+            onDismiss = { selectedMsg = null })
         return
     }
 
@@ -480,160 +493,19 @@ fun ChatScreen(
     Box(modifier = Modifier.fillMaxSize()) {
         ScreenScaffold(scrollState = listState) {
             ScalingLazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-            item(key = "channel_title") { Text("#$channelName", style = MaterialTheme.typography.titleMedium) }
-
-            if (pendingText.isNotBlank()) {
-                item(key = "pending_text") {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(
-                                MaterialTheme.colorScheme.surfaceContainer,
-                                RoundedCornerShape(8.dp)
-                            )
-                            .padding(horizontal = 8.dp, vertical = 4.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            pendingText,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
-                            maxLines = 2
-                        )
-                        Row {
-                            Text(
-                                "▶", //set to material send ivcon instead of Unicode
-                                style = MaterialTheme.typography.labelSmall,
-                                color = if (slowRemaining > 0)
-                                    MaterialTheme.colorScheme.onSurfaceVariant
-                                else MaterialTheme.colorScheme.primary,
-                                modifier = Modifier
-                                    .clickable {
-                                        if (slowRemaining > 0) return@clickable
-                                        val text = pendingText
-                                        pendingText = ""
-                                        inputText = ""
-                                        scope.launch {
-                                            slowRemaining = slowModeSecs
-                                            val replyTarget = replyingTo
-                                            if (replyTarget != null) {
-                                                repo.sendReply(channelId, text, replyTarget.id)
-                                                    .onFailure { sendError = "Failed: ${it.message}" }
-                                                replyingTo = null
-                                            } else {
-                                                repo.sendMessage(channelId, text)
-                                                    .onFailure { sendError = "Failed: ${it.message}" }
-                                            }
-                                            while (true) {
-                                                delay(1_000)
-                                                slowRemaining = repo.slowModeRemainingSeconds(channelId)
-                                                if (slowRemaining <= 0) break
-                                            }
-                                        }
-                                    }
-                                    .padding(horizontal = 6.dp, vertical = 4.dp)
-                            )
-                            Text(
-                                "X",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier
-                                    .clickable {
-                                        pendingText = ""
-                                        inputText = ""
-                                    }
-                                    .padding(4.dp)
-                            )
-                        }
-                    }
-                }
-            }
-
-            when {
-                loading -> item(key = "loading") { CircularProgressIndicator() }
-                messages.isEmpty() -> item(key = "empty") {
-                    Text("No messages yet.", style = MaterialTheme.typography.bodySmall)
-                }
-                else -> items(messages.size, key = { messages[it].id }) { index ->
-                    val msg = messages[index]
-                    val prevMsg = if (index > 0) messages[index - 1] else null
-                    fun String.toEpochMillis(): Long = runCatching {
-                        java.time.OffsetDateTime.parse(this).toInstant().toEpochMilli()
-                    }.getOrElse { 0L }
-
-                    val gapMs = if (prevMsg != null)
-                        msg.timestamp.toEpochMillis() - prevMsg.timestamp.toEpochMillis()
-                    else Long.MAX_VALUE
-
-                    val isContinuation = prevMsg != null &&
-                        prevMsg.author.id == msg.author.id &&
-                        msg.type !in listOf(19, 23) &&
-                        prevMsg.type !in listOf(19, 23) &&
-                        gapMs < 10 * 60 * 1000L
-
-                    MessageBubble(
-                        msg = msg,
-                        isOwn = msg.author.id == myId,
-                        isContinuation = isContinuation,
-                        imageLoader = imageLoader,
-                        channelNames = channelNames,
-                        compactMode = compactMode,
-                        spoilerRevealOnTap = spoilerRevealOnTap,
-                        guildId = guildId,
-                        roleColorCache = roleColorCache,
-                        onReact = { emoji ->
-                            scope.launch { repo.toggleReaction(channelId, msg.id, emoji) }
-                        },
-                        onSwipeLeft = {
-                            replyingTo = msg
-                        },
-                        onLongPress = {
-                            selectedMsg = msg
-                        },
-                        onAvatarClick = { userId ->
-                            onNavigateToProfile?.invoke(userId, msg.author.takeIf { it.id == userId })
-                        }
-                    )
-                }
-            }
-
-            if (sendError.isNotEmpty()) {
-                item(key = "send_error") {
-                    Text(sendError, color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall)
-                }
-            }
-
-            // this BS not worky :(
-          //  val currentTypingUsers = typingMap[channelId].orEmpty().filter { it != myId }
-            //if (currentTypingUsers.isNotEmpty()) {
-              /*  item(key = "typing_indicator") {
-                    val names = currentTypingUsers.mapNotNull { uid -> repo.getDisplayName(uid) }
-                    val label = when {
-                        names.isEmpty() -> "Someone is typing…"
-                        names.size == 1 -> "${names[0]} is typing…"
-                        names.size == 2 -> "${names[0]} and ${names[1]} are typing…"
-                        else            -> "Several people are typing…"
-                    }
+                item(key = "channel_title") {
                     Text(
-                        text = label,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 2.dp)
+                        "#$channelName", style = MaterialTheme.typography.titleMedium
                     )
                 }
-            //}*/
 
-            item(key = "text_input") {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    if (replyingTo != null) {
+                if (pendingText.isNotBlank()) {
+                    item(key = "pending_text") {
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .background(
-                                    MaterialTheme.colorScheme.secondaryContainer,
+                                    MaterialTheme.colorScheme.surfaceContainer,
                                     RoundedCornerShape(8.dp)
                                 )
                                 .padding(horizontal = 8.dp, vertical = 4.dp),
@@ -641,212 +513,403 @@ fun ChatScreen(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
-                                "↩ ${replyingTo!!.author.displayName}: ${replyingTo!!.content.take(30)}",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                modifier = Modifier.weight(1f)
+                                pendingText,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f),
+                                maxLines = 2
                             )
-                            Text(
-                                "X",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                modifier = Modifier.clickable { replyingTo = null }.padding(4.dp)
-                            )
-                        }
-                    }
-
-                if (canSend) {
-                    OutlinedTextField(
-                        value = inputText,
-                        onValueChange = { newValue ->
-                            inputText = newValue
-                            pendingText = newValue
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        placeholder = { Text("Message #$channelName", color = MaterialTheme.colorScheme.onSurfaceVariant) },
-                        textStyle = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.onSurface),
-                        colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
-                            focusedTextColor = MaterialTheme.colorScheme.onSurface,
-                            unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-                            cursorColor = MaterialTheme.colorScheme.primary
-                        ),
-                        minLines = 1,
-                        maxLines = 4,
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done)
-                    )
-                } else {
-                    Text(
-                        text = "You cannot send messages here",//add lock icon from /res/drawable
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
-                    )
-                }
-                } 
-            }
-
-            item(key = "action_buttons") {
-                if (canSend) {
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(6.dp),
-                    horizontalArrangement = Arrangement.spacedBy(space = 16.dp, alignment = Alignment.CenterHorizontally)
-                ) {
-                    FilledIconButton(
-                        onClick = {
-                            reactingToMsg = null
-                            showPicker = true
-                            tab = 0
-                        },
-                        modifier = Modifier.height(40.dp).width(40.dp),
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.emoji),
-                            contentDescription = "Emoji"
-                        )
-                    }
-                    FilledIconButton(
-                        onClick = {
-                            reactingToMsg = null
-                            showPicker = true
-                            tab = 1
-                        },
-                        modifier = Modifier.height(40.dp).width(40.dp),
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.sticker),
-                            contentDescription = "Stickers"
-                        )
-                    }
-                    FilledIconButton(
-                        onClick = {
-                            val text = inputText.trim()
-                            if (text.isBlank() || slowRemaining > 0) return@FilledIconButton
-                            inputText = ""
-                            pendingText = ""
-                            scope.launch {
-                               slowRemaining = slowModeSecs
-                               val replyTarget = replyingTo
-                               if (replyTarget != null) {
-                                   repo.sendReply(channelId, text, replyTarget.id)
-                                       .onFailure { sendError = "Failed: ${it.message}" }
-                                   replyingTo = null
-                               } else {
-                                   repo.sendMessage(channelId, text)
-                                       .onFailure { sendError = "Failed: ${it.message}" }
-                               }
-                               while (true) {
-                                   delay(1_000)
-                                   slowRemaining = repo.slowModeRemainingSeconds(channelId)
-                                   if (slowRemaining <= 0) break
-                               }
+                            Row {
+                                Text(
+                                    "▶", //set to material send ivcon instead of Unicode
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = if (slowRemaining > 0) MaterialTheme.colorScheme.onSurfaceVariant
+                                    else MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier
+                                        .clickable {
+                                            if (slowRemaining > 0) return@clickable
+                                            val text = pendingText
+                                            pendingText = ""
+                                            inputText = ""
+                                            scope.launch {
+                                                slowRemaining = slowModeSecs
+                                                val replyTarget = replyingTo
+                                                if (replyTarget != null) {
+                                                    repo.sendReply(channelId, text, replyTarget.id)
+                                                        .onFailure {
+                                                            sendError = "Failed: ${it.message}"
+                                                        }
+                                                    replyingTo = null
+                                                } else {
+                                                    repo.sendMessage(channelId, text).onFailure {
+                                                        sendError = "Failed: ${it.message}"
+                                                    }
+                                                }
+                                                while (true) {
+                                                    delay(1_000)
+                                                    slowRemaining =
+                                                        repo.slowModeRemainingSeconds(channelId)
+                                                    if (slowRemaining <= 0) break
+                                                }
+                                            }
+                                        }
+                                        .padding(horizontal = 6.dp, vertical = 4.dp))
+                                Text(
+                                    "X",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier
+                                        .clickable {
+                                            pendingText = ""
+                                            inputText = ""
+                                        }
+                                        .padding(4.dp))
                             }
-                        },
-                        modifier = Modifier.height(40.dp).width(40.dp),
-                        enabled = inputText.isNotBlank() && slowRemaining <= 0
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.send),
-                            contentDescription = "Send"
-                        )
+                        }
                     }
                 }
-                
-                if (!isRecording) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(6.dp),
-                     horizontalArrangement = Arrangement.spacedBy(space = 16.dp, alignment = Alignment.CenterHorizontally)
 
-                    ) {
-                        FilledIconButton(
-                            onClick = {
-                                val perm = if (android.os.Build.VERSION.SDK_INT >= 33)
-                                    Manifest.permission.READ_MEDIA_IMAGES
-                                else
-                                    Manifest.permission.READ_EXTERNAL_STORAGE
-                                val hasPerm = ContextCompat.checkSelfPermission(context, perm) ==
-                                    PackageManager.PERMISSION_GRANTED
-                                if (hasPerm) {
-                                    showPhotoPicker = true
-                                } else {
-                                    imagePermLauncher.launch(perm)
-                                }
+                when {
+                    loading -> item(key = "loading") { CircularProgressIndicator() }
+                    messages.isEmpty() -> item(key = "empty") {
+                        Text("No messages yet.", style = MaterialTheme.typography.bodySmall)
+                    }
+
+                    else -> items(messages.size, key = { messages[it].id }) { index ->
+                        val msg = messages[index]
+                        val prevMsg = if (index > 0) messages[index - 1] else null
+                        fun String.toEpochMillis(): Long = runCatching {
+                            java.time.OffsetDateTime.parse(this).toInstant().toEpochMilli()
+                        }.getOrElse { 0L }
+
+                        val gapMs =
+                            if (prevMsg != null) msg.timestamp.toEpochMillis() - prevMsg.timestamp.toEpochMillis()
+                            else Long.MAX_VALUE
+
+                        val isContinuation =
+                            prevMsg != null && prevMsg.author.id == msg.author.id && msg.type !in listOf(
+                                19,
+                                23
+                            ) && prevMsg.type !in listOf(19, 23) && gapMs < 10 * 60 * 1000L
+
+                        MessageBubble(
+                            msg = msg,
+                            isOwn = msg.author.id == myId,
+                            isContinuation = isContinuation,
+                            imageLoader = imageLoader,
+                            channelNames = channelNames,
+                            compactMode = compactMode,
+                            spoilerRevealOnTap = spoilerRevealOnTap,
+                            guildId = guildId,
+                            roleColorCache = roleColorCache,
+                            onReact = { emoji ->
+                                scope.launch { repo.toggleReaction(channelId, msg.id, emoji) }
                             },
-                            modifier = Modifier.height(40.dp).width(40.dp),
-                        ) {
-                            Icon(
-                                painter = painterResource(id = R.drawable.image),
-                                contentDescription = "Upload Photo"
-                            )
-                        }
-                        FilledIconButton(
-                            onClick = { startRecording() },
-                            modifier = Modifier.height(40.dp).width(40.dp),
-                        ) {
-                            Icon(
-                                painter = painterResource(id = R.drawable.mic),
-                                contentDescription = "Voice Message"
-                            )
+                            onSwipeLeft = {
+                                replyingTo = msg
+                            },
+                            onLongPress = {
+                                selectedMsg = msg
+                            },
+                            onAvatarClick = { userId ->
+                                onNavigateToProfile?.invoke(
+                                    userId, msg.author.takeIf { it.id == userId })
+                            })
+                    }
+                }
+
+                if (sendError.isNotEmpty()) {
+                    item(key = "send_error") {
+                        Text(
+                            sendError,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+
+                // this BS not worky :(
+                //  val currentTypingUsers = typingMap[channelId].orEmpty().filter { it != myId }
+                //if (currentTypingUsers.isNotEmpty()) {
+                /*  item(key = "typing_indicator") {
+                      val names = currentTypingUsers.mapNotNull { uid -> repo.getDisplayName(uid) }
+                      val label = when {
+                          names.isEmpty() -> "Someone is typing…"
+                          names.size == 1 -> "${names[0]} is typing…"
+                          names.size == 2 -> "${names[0]} and ${names[1]} are typing…"
+                          else            -> "Several people are typing…"
+                      }
+                      Text(
+                          text = label,
+                          style = MaterialTheme.typography.labelSmall,
+                          color = MaterialTheme.colorScheme.onSurfaceVariant,
+                          modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 2.dp)
+                      )
+                  }
+              //}*/
+
+                item(key = "text_input") {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        if (replyingTo != null) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(
+                                        MaterialTheme.colorScheme.secondaryContainer,
+                                        RoundedCornerShape(8.dp)
+                                    )
+                                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    "↩ ${replyingTo!!.author.displayName}: ${
+                                        replyingTo!!.content.take(
+                                            30
+                                        )
+                                    }",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                Text(
+                                    "X",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier
+                                        .clickable { replyingTo = null }
+                                        .padding(4.dp))
+                            }
                         }
 
-                        FilledIconButton(
-                            onClick = { inputText += "||"; },
-                            modifier = Modifier
-                                .width(40.dp)
-                                .height(40.dp)
-                        ) {
-                            Icon(
-                                painter = painterResource(id = R.drawable.spoiler),
-                                contentDescription = "Text Spoiler"
+                        if (canSend) {
+                            OutlinedTextField(
+                                value = inputText,
+                                onValueChange = { newValue ->
+                                    inputText = newValue
+                                    pendingText = newValue
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                placeholder = {
+                                    Text(
+                                        "Message #$channelName",
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                },
+                                textStyle = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.onSurface),
+                                colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
+                                    focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                    unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                    cursorColor = MaterialTheme.colorScheme.primary
+                                ),
+                                minLines = 1,
+                                maxLines = 4,
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done)
+                            )
+                        } else {
+                            Text(
+                                text = "You cannot send messages here",//add lock icon from /res/drawable
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 4.dp)
                             )
                         }
                     }
-                } else {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(MaterialTheme.colorScheme.errorContainer, RoundedCornerShape(8.dp))
-                            .padding(horizontal = 8.dp, vertical = 6.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        val mins = recordingSecs / 60
-                        val secs = recordingSecs % 60
-                        Text(
-                            text = "%02d:%02d".format(mins, secs),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onErrorContainer
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceEvenly
-                        ) {
-                            Button(
-                                onClick = { cancelRecording() },
-                                modifier = Modifier.weight(1f).height(34.dp),
-                                colors = ButtonDefaults.outlinedButtonColors()
-                            ) { Text("Cancel", fontSize = 12.sp) }
-                            Spacer(Modifier.width(6.dp))
-                            Button(
-                                onClick = { stopAndSendRecording() },
-                                modifier = Modifier.weight(1f).height(34.dp),
-                                colors = ButtonDefaults.filledTonalButtonColors()
-                            ) { Text("Send", fontSize = 11.sp) }
+                }
+
+                item(key = "action_buttons") {
+                    if (canSend) {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(6.dp),
+                                horizontalArrangement = Arrangement.spacedBy(
+                                    space = 16.dp, alignment = Alignment.CenterHorizontally
+                                )
+                            ) {
+                                FilledIconButton(
+                                    onClick = {
+                                        reactingToMsg = null
+                                        showPicker = true
+                                        tab = 0
+                                    },
+                                    modifier = Modifier
+                                        .height(40.dp)
+                                        .width(40.dp),
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.emoji),
+                                        contentDescription = "Emoji"
+                                    )
+                                }
+                                FilledIconButton(
+                                    onClick = {
+                                        reactingToMsg = null
+                                        showPicker = true
+                                        tab = 1
+                                    },
+                                    modifier = Modifier
+                                        .height(40.dp)
+                                        .width(40.dp),
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.sticker),
+                                        contentDescription = "Stickers"
+                                    )
+                                }
+                                FilledIconButton(
+                                    onClick = {
+                                        val text = inputText.trim()
+                                        if (text.isBlank() || slowRemaining > 0) return@FilledIconButton
+                                        inputText = ""
+                                        pendingText = ""
+                                        scope.launch {
+                                            slowRemaining = slowModeSecs
+                                            val replyTarget = replyingTo
+                                            if (replyTarget != null) {
+                                                repo.sendReply(channelId, text, replyTarget.id)
+                                                    .onFailure {
+                                                        sendError = "Failed: ${it.message}"
+                                                    }
+                                                replyingTo = null
+                                            } else {
+                                                repo.sendMessage(channelId, text).onFailure {
+                                                    sendError = "Failed: ${it.message}"
+                                                }
+                                            }
+                                            while (true) {
+                                                delay(1_000)
+                                                slowRemaining =
+                                                    repo.slowModeRemainingSeconds(channelId)
+                                                if (slowRemaining <= 0) break
+                                            }
+                                        }
+                                    },
+                                    modifier = Modifier
+                                        .height(40.dp)
+                                        .width(40.dp),
+                                    enabled = inputText.isNotBlank() && slowRemaining <= 0
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.send),
+                                        contentDescription = "Send"
+                                    )
+                                }
+                            }
+
+                            if (!isRecording) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(6.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(
+                                        space = 16.dp, alignment = Alignment.CenterHorizontally
+                                    )
+
+                                ) {
+                                    FilledIconButton(
+                                        onClick = {
+                                            val perm =
+                                                if (android.os.Build.VERSION.SDK_INT >= 33) Manifest.permission.READ_MEDIA_IMAGES
+                                                else Manifest.permission.READ_EXTERNAL_STORAGE
+                                            val hasPerm = ContextCompat.checkSelfPermission(
+                                                context,
+                                                perm
+                                            ) == PackageManager.PERMISSION_GRANTED
+                                            if (hasPerm) {
+                                                showPhotoPicker = true
+                                            } else {
+                                                imagePermLauncher.launch(perm)
+                                            }
+                                        },
+                                        modifier = Modifier
+                                            .height(40.dp)
+                                            .width(40.dp),
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(id = R.drawable.image),
+                                            contentDescription = "Upload Photo"
+                                        )
+                                    }
+                                    FilledIconButton(
+                                        onClick = { startRecording() },
+                                        modifier = Modifier
+                                            .height(40.dp)
+                                            .width(40.dp),
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(id = R.drawable.mic),
+                                            contentDescription = "Voice Message"
+                                        )
+                                    }
+
+                                    FilledIconButton(
+                                        onClick = { inputText += "||"; },
+                                        modifier = Modifier
+                                            .width(40.dp)
+                                            .height(40.dp)
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(id = R.drawable.spoiler),
+                                            contentDescription = "Text Spoiler"
+                                        )
+                                    }
+                                }
+                            } else {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(
+                                            MaterialTheme.colorScheme.errorContainer,
+                                            RoundedCornerShape(8.dp)
+                                        )
+                                        .padding(horizontal = 8.dp, vertical = 6.dp),
+                                    horizontalAlignment = Alignment.CenterHorizontally
+                                ) {
+                                    val mins = recordingSecs / 60
+                                    val secs = recordingSecs % 60
+                                    Text(
+                                        text = "%02d:%02d".format(mins, secs),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onErrorContainer
+                                    )
+                                    Spacer(Modifier.height(4.dp))
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceEvenly
+                                    ) {
+                                        Button(
+                                            onClick = { cancelRecording() },
+                                            modifier = Modifier
+                                                .weight(1f)
+                                                .height(34.dp),
+                                            colors = ButtonDefaults.outlinedButtonColors()
+                                        ) { Text("Cancel", fontSize = 12.sp) }
+                                        Spacer(Modifier.width(6.dp))
+                                        Button(
+                                            onClick = { stopAndSendRecording() },
+                                            modifier = Modifier
+                                                .weight(1f)
+                                                .height(34.dp),
+                                            colors = ButtonDefaults.filledTonalButtonColors()
+                                        ) { Text("Send", fontSize = 11.sp) }
+                                    }
+                                }
+                            }
+                            if (uploadError.isNotEmpty()) {
+                                Text(
+                                    uploadError,
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    modifier = Modifier.clickable { uploadError = "" })
+                            }
                         }
                     }
                 }
-                if (uploadError.isNotEmpty()) {
-                    Text(
-                        uploadError,
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.labelSmall,
-                        modifier = Modifier.clickable { uploadError = "" }
-                    )
-                }
-                }
             }
-            }
-        }
         }
 
         if (!isAtBottom) {//need to be higher up to show this
@@ -861,8 +924,7 @@ fun ChatScreen(
                     modifier = Modifier.size(32.dp)
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.down),
-                        contentDescription = "Down"
+                        painter = painterResource(id = R.drawable.down), contentDescription = "Down"
                     )
                 }
             }
@@ -879,7 +941,7 @@ private fun SpoilerText(text: String, revealOnTap: Boolean) {
             text = text,
             style = MaterialTheme.typography.bodySmall,
             color = if (revealed) MaterialTheme.colorScheme.onSurface
-                    else          MaterialTheme.colorScheme.onSurface.copy(alpha = 0f)
+            else MaterialTheme.colorScheme.onSurface.copy(alpha = 0f)
         )
         if (!revealed) {
             Text(
@@ -901,17 +963,13 @@ fun parseInsertTextToReactionEmoji(insertText: String): ReactionEmoji? {
     val animatedMatch = Regex("""<a:(\w+):(\d+)>""").find(insertText)
     if (animatedMatch != null) {
         return ReactionEmoji(
-            id = animatedMatch.groupValues[2],
-            name = animatedMatch.groupValues[1],
-            animated = true
+            id = animatedMatch.groupValues[2], name = animatedMatch.groupValues[1], animated = true
         )
     }
     val customMatch = Regex("""<:(\w+):(\d+)>""").find(insertText)
     if (customMatch != null) {
         return ReactionEmoji(
-            id = customMatch.groupValues[2],
-            name = customMatch.groupValues[1],
-            animated = false
+            id = customMatch.groupValues[2], name = customMatch.groupValues[1], animated = false
         )
     }
     if (insertText.isNotBlank()) {
@@ -945,10 +1003,17 @@ private fun MessageOptionsDialog(
             item {
                 Button(
                     onClick = onReply,
-                    modifier = Modifier.fillMaxWidth().height(36.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(36.dp),
                     colors = ButtonDefaults.filledTonalButtonColors()
                 ) {
-                    Icon(painter = painterResource(id = R.drawable.reply), contentDescription = null,tint = Color.White, modifier = Modifier.size(16.dp))
+                    Icon(
+                        painter = painterResource(id = R.drawable.reply),
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp)
+                    )
                     Spacer(Modifier.width(6.dp))
                     Text("Reply")
                 }
@@ -956,10 +1021,17 @@ private fun MessageOptionsDialog(
             item {
                 Button(
                     onClick = onReact,
-                    modifier = Modifier.fillMaxWidth().height(36.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(36.dp),
                     colors = ButtonDefaults.filledTonalButtonColors()
                 ) {
-                    Icon(painter = painterResource(id = R.drawable.emoji), contentDescription = null,tint = Color.White, modifier = Modifier.size(16.dp))
+                    Icon(
+                        painter = painterResource(id = R.drawable.emoji),
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp)
+                    )
                     Spacer(Modifier.width(6.dp))
                     Text("React")
                 }
@@ -967,10 +1039,17 @@ private fun MessageOptionsDialog(
             item {
                 Button(
                     onClick = onCopy,
-                    modifier = Modifier.fillMaxWidth().height(36.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(36.dp),
                     colors = ButtonDefaults.filledTonalButtonColors()
                 ) {
-                    Icon(painter = painterResource(id = R.drawable.copy), contentDescription = null,tint = Color.White, modifier = Modifier.size(16.dp))
+                    Icon(
+                        painter = painterResource(id = R.drawable.copy),
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp)
+                    )
                     Spacer(Modifier.width(6.dp))
                     Text("Copy Text")
                 }
@@ -979,10 +1058,17 @@ private fun MessageOptionsDialog(
                 item {
                     Button(
                         onClick = onEdit,
-                        modifier = Modifier.fillMaxWidth().height(36.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(36.dp),
                         colors = ButtonDefaults.filledTonalButtonColors()
                     ) {
-                        Icon(painter = painterResource(id = R.drawable.edit), contentDescription = null,tint = Color.White, modifier = Modifier.size(16.dp))
+                        Icon(
+                            painter = painterResource(id = R.drawable.edit),
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(16.dp)
+                        )
                         Spacer(Modifier.width(6.dp))
                         Text("Edit")
                     }
@@ -990,12 +1076,19 @@ private fun MessageOptionsDialog(
                 item {
                     Button(
                         onClick = onDelete,
-                        modifier = Modifier.fillMaxWidth().height(36.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(36.dp),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.error
                         )
                     ) {
-                        Icon(painter = painterResource(id = R.drawable.delete), contentDescription = null,tint = Color.White, modifier = Modifier.size(16.dp))
+                        Icon(
+                            painter = painterResource(id = R.drawable.delete),
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(16.dp)
+                        )
                         Spacer(Modifier.width(6.dp))
                         Text("Delete")
                     }
@@ -1004,7 +1097,9 @@ private fun MessageOptionsDialog(
             item {
                 Button(
                     onClick = onDismiss,
-                    modifier = Modifier.fillMaxWidth().height(36.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(36.dp),
                     colors = ButtonDefaults.outlinedButtonColors()
                 ) { Text("Cancel") }
             }
@@ -1039,10 +1134,9 @@ private fun MessageBubble(
     // Role data is pre-loaded in ChatScreen for all visible authors
     val topRole = if (guildId != null) roleColorCache[msg.author.id] else null
     val rawRoleColor = topRole?.color
-    val authorNameColor = if (rawRoleColor != null && rawRoleColor != 0)
-        Color(0xFF000000.toInt() or rawRoleColor)
-    else
-        MaterialTheme.colorScheme.onSurfaceVariant
+    val authorNameColor =
+        if (rawRoleColor != null && rawRoleColor != 0) Color(0xFF000000.toInt() or rawRoleColor)
+        else MaterialTheme.colorScheme.onSurfaceVariant
     var offsetX by remember { mutableStateOf(0f) }
 
     Row(
@@ -1050,15 +1144,12 @@ private fun MessageBubble(
             .fillMaxWidth()
             .padding(top = if (isContinuation) 0.dp else 4.dp, bottom = 2.dp)
             .pointerInput(Unit) {
-                detectHorizontalDragGestures(
-                    onDragEnd = {
-                        if (offsetX < -40f) onSwipeLeft()
-                        offsetX = 0f
-                    },
-                    onHorizontalDrag = { _, delta ->
-                        if (delta < 0) offsetX += delta
-                    }
-                )
+                detectHorizontalDragGestures(onDragEnd = {
+                    if (offsetX < -40f) onSwipeLeft()
+                    offsetX = 0f
+                }, onHorizontalDrag = { _, delta ->
+                    if (delta < 0) offsetX += delta
+                })
             }
             .pointerInput(Unit) {
                 awaitPointerEventScope {
@@ -1072,9 +1163,9 @@ private fun MessageBubble(
                             var moved = false
                             while (System.currentTimeMillis() < endTime) {
                                 val ev = awaitPointerEvent()
-                                if (ev.changes.all { !it.pressed }) { 
+                                if (ev.changes.all { !it.pressed }) {
                                     lifted = true
-                                    break 
+                                    break
                                 }
                                 // Check if pointer moved more than 10dp — if so, it's a scroll/drag
                                 val currentPos = ev.changes.first().position
@@ -1092,25 +1183,21 @@ private fun MessageBubble(
                         }
                     }
                 }
-            },
-        horizontalArrangement = Arrangement.Start,
-        verticalAlignment = Alignment.Top
+            }, horizontalArrangement = Arrangement.Start, verticalAlignment = Alignment.Top
     ) {
         if (!compactMode && !isOwn && !isContinuation) {
             DiscordAvatarWithDecoration(
                 user = msg.author,
                 imageLoader = imageLoader,
                 size = 22.dp,
-                onClick = { onAvatarClick(msg.author.id) }
-            )
+                onClick = { onAvatarClick(msg.author.id) })
             Spacer(Modifier.width(4.dp))
         } else if (!compactMode && !isOwn) {
             Spacer(Modifier.width(26.dp))
         }
 
         Column(
-            horizontalAlignment = Alignment.Start,
-            modifier = Modifier.widthIn(max = 155.dp)
+            horizontalAlignment = Alignment.Start, modifier = Modifier.widthIn(max = 155.dp)
         ) {
             if (!isContinuation) {
                 val timeLabel = remember(msg.timestamp) {
@@ -1119,18 +1206,17 @@ private fun MessageBubble(
                         val zoned = instant.atZone(java.time.ZoneId.systemDefault())
                         val now = java.time.ZonedDateTime.now()
                         val use24 = android.text.format.DateFormat.is24HourFormat(context)
-                        val timeFmt = if (use24)
-                            java.time.format.DateTimeFormatter.ofPattern("HH:mm")
-                        else
-                            java.time.format.DateTimeFormatter.ofPattern("h:mma")
+                        val timeFmt =
+                            if (use24) java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+                            else java.time.format.DateTimeFormatter.ofPattern("h:mma")
                         val timeStr = zoned.format(timeFmt).lowercase()
 
                         val todayDate = now.toLocalDate()
                         val yesterdayDate = todayDate.minusDays(1)
                         when (zoned.toLocalDate()) {
-                            todayDate     -> timeStr
+                            todayDate -> timeStr
                             yesterdayDate -> "Yesterday $timeStr"
-                            else          -> "${zoned.monthValue}/${zoned.dayOfMonth} $timeStr"
+                            else -> "${zoned.monthValue}/${zoned.dayOfMonth} $timeStr"
                         }
                     }.getOrElse { "" }
                 }
@@ -1148,22 +1234,19 @@ private fun MessageBubble(
                         when {
                             !topRole.unicodeEmoji.isNullOrEmpty() -> {
                                 Text(
-                                    text = topRole.unicodeEmoji,
-                                    fontSize = 10.sp
+                                    text = topRole.unicodeEmoji, fontSize = 10.sp
                                 )
                             }
+
                             !topRole.iconHash.isNullOrEmpty() -> {
                                 SubcomposeAsyncImage(
                                     model = ImageRequest.Builder(LocalContext.current)
-                                        .data(topRole.iconUrl())
-                                        .crossfade(true)
-                                        .build(),
+                                        .data(topRole.iconUrl()).crossfade(true).build(),
                                     contentDescription = null,
                                     imageLoader = imageLoader,
                                     modifier = Modifier.size(12.dp),
                                     loading = { /* Hide while loading */ },
-                                    error = { /* Hide on error */ }
-                                )
+                                    error = { /* Hide on error */ })
                             }
                         }
                     }
@@ -1210,8 +1293,7 @@ private fun MessageBubble(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            MaterialTheme.colorScheme.secondaryContainer,
-                            RoundedCornerShape(6.dp)
+                            MaterialTheme.colorScheme.secondaryContainer, RoundedCornerShape(6.dp)
                         )
                         .padding(6.dp)
                 ) {
@@ -1303,14 +1385,12 @@ private fun MessageBubble(
             msg.stickers.filter { it.isDisplayable }.forEach { s ->
                 MediaImage(s.imageUrl, s.name, imageLoader, size = 80.dp)
             }
-            msg.embeds
-                .filter { embed ->
-                    !(embed.type == "link" && //lets clean this up a litlle more
+            msg.embeds.filter { embed ->
+                !(embed.type == "link" && //lets clean this up a litlle more
                         embed.url?.contains("cdn.discordapp.com/emojis/") == true)
-                }
-                .forEach { embed ->
-                    EmbedCard(embed, imageLoader)
-                }
+            }.forEach { embed ->
+                EmbedCard(embed, imageLoader)
+            }
 
             if (msg.reactions.isNotEmpty()) {
                 FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -1339,7 +1419,6 @@ private fun MessageContent(
     val parts = remember(content, userNames, roleNames, channelNames) {
         ContentParser.parse(content, userNames, roleNames, channelNames)
     }
-
     FlowRow(modifier = Modifier.fillMaxWidth()) {
         parts.forEach { part ->
             when (part) {
@@ -1352,18 +1431,17 @@ private fun MessageContent(
                             val annotated = buildAnnotatedString {
                                 val style = SpanStyle(
                                     fontWeight = if (span.bold) androidx.compose.ui.text.font.FontWeight.Bold
-                                                 else null,
+                                    else null,
                                     fontStyle = if (span.italic) androidx.compose.ui.text.font.FontStyle.Italic
-                                                 else null,
+                                    else null,
+                                    fontSize = if (span.subtext) 8.sp else TextUnit.Unspecified,
                                     textDecoration = when {
                                         span.strikethrough -> TextDecoration.LineThrough
-                                        else               -> null
+                                        else -> null
                                     },
-                                    background = if (span.code)
-                                        MaterialTheme.colorScheme.surfaceContainer
+                                    background = if (span.code) MaterialTheme.colorScheme.surfaceContainer
                                     else androidx.compose.ui.graphics.Color.Unspecified,
-                                    fontFamily = if (span.code)
-                                        androidx.compose.ui.text.font.FontFamily.Monospace
+                                    fontFamily = if (span.code) androidx.compose.ui.text.font.FontFamily.Monospace
                                     else null
                                 )
                                 withStyle(style) { append(span.text) }
@@ -1372,24 +1450,29 @@ private fun MessageContent(
                         }
                     }
                 }
+
                 is ContentParser.Part.CustomEmoji -> {
                     AsyncImage(
-                        model = ImageRequest.Builder(context)
-                            .data(part.url).crossfade(true).build(),
+                        model = ImageRequest.Builder(context).data(part.url).crossfade(true)
+                            .build(),
                         imageLoader = imageLoader,
                         contentDescription = part.name,
                         modifier = Modifier.size(18.dp)
                     )
                 }
+
                 is ContentParser.Part.UserMention -> {
                     val annotated = buildAnnotatedString {
-                        withStyle(SpanStyle(
-                            color = MaterialTheme.colorScheme.primary,
-                            background = MaterialTheme.colorScheme.primaryContainer
-                        )) { append("@${part.displayName}") }
+                        withStyle(
+                            SpanStyle(
+                                color = MaterialTheme.colorScheme.primary,
+                                background = MaterialTheme.colorScheme.primaryContainer
+                            )
+                        ) { append("@${part.displayName}") }
                     }
                     Text(text = annotated, style = MaterialTheme.typography.bodySmall)
                 }
+
                 is ContentParser.Part.RoleMention -> {
                     val annotated = buildAnnotatedString {
                         withStyle(SpanStyle(color = MaterialTheme.colorScheme.tertiary)) {
@@ -1398,6 +1481,7 @@ private fun MessageContent(
                     }
                     Text(text = annotated, style = MaterialTheme.typography.bodySmall)
                 }
+
                 is ContentParser.Part.ChannelMention -> {
                     val annotated = buildAnnotatedString {
                         withStyle(SpanStyle(color = MaterialTheme.colorScheme.secondary)) {
@@ -1406,24 +1490,28 @@ private fun MessageContent(
                     }
                     Text(text = annotated, style = MaterialTheme.typography.bodySmall)
                 }
+
                 is ContentParser.Part.Link -> {
                     val annotated = buildAnnotatedString {
-                        withStyle(SpanStyle(
-                            color = MaterialTheme.colorScheme.primary,
-                            textDecoration = TextDecoration.Underline
-                        )) { append(part.url) }
+                        withStyle(
+                            SpanStyle(
+                                color = MaterialTheme.colorScheme.primary,
+                                textDecoration = TextDecoration.Underline
+                            )
+                        ) { append(part.url) }
                     }
                     Text(
                         text = annotated,
                         style = MaterialTheme.typography.bodySmall,
                         modifier = Modifier.clickable {
                             runCatching {
-                                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(part.url))
-                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                val intent = Intent(
+                                    Intent.ACTION_VIEW,
+                                    Uri.parse(part.url)
+                                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                                 context.startActivity(intent)
                             }
-                        }
-                    )
+                        })
                 }
             }
         }
@@ -1432,19 +1520,15 @@ private fun MessageContent(
 
 @Composable
 private fun ReactionChip(reaction: Reaction, imageLoader: ImageLoader, onClick: () -> Unit) {
-    val bgColor = if (reaction.me)
-        MaterialTheme.colorScheme.primaryContainer
-    else
-        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+    val bgColor = if (reaction.me) MaterialTheme.colorScheme.primaryContainer
+    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
 
     Box(
         modifier = Modifier
             .height(22.dp)
             .background(color = bgColor, shape = RoundedCornerShape(11.dp))
             .clickable { onClick() }
-            .padding(horizontal = 6.dp),
-        contentAlignment = Alignment.Center
-    ) {
+            .padding(horizontal = 6.dp), contentAlignment = Alignment.Center) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(3.dp)
@@ -1452,8 +1536,8 @@ private fun ReactionChip(reaction: Reaction, imageLoader: ImageLoader, onClick: 
             val imgUrl = reaction.emoji.imageUrl
             if (imgUrl != null) {
                 AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data(imgUrl).crossfade(true).build(),
+                    model = ImageRequest.Builder(LocalContext.current).data(imgUrl).crossfade(true)
+                        .build(),
                     imageLoader = imageLoader,
                     contentDescription = reaction.emoji.name,
                     modifier = Modifier.size(14.dp)
@@ -1477,38 +1561,85 @@ private fun ReactionChip(reaction: Reaction, imageLoader: ImageLoader, onClick: 
 }
 
 @Composable
-private fun MediaImage(url: String, contentDesc: String, imageLoader: ImageLoader, size: Dp = 120.dp) {
+private fun MediaImage(
+    url: String, contentDesc: String, imageLoader: ImageLoader, size: Dp = 120.dp
+) {
     AsyncImage(
-        model = ImageRequest.Builder(LocalContext.current)
-            .data(url).crossfade(true).build(),
+        model = ImageRequest.Builder(LocalContext.current).data(url).crossfade(true).build(),
         imageLoader = imageLoader,
         contentDescription = contentDesc,
         contentScale = ContentScale.Fit,
-        modifier = Modifier.padding(top = 2.dp).widthIn(max = size).heightIn(max = size)
+        modifier = Modifier
+            .padding(top = 2.dp)
+            .widthIn(max = size)
+            .heightIn(max = size)
     )
 }
 
 @Composable
 private fun EmbedCard(embed: Embed, imageLoader: ImageLoader) {
-    Column(modifier = Modifier.padding(top = 2.dp)) {
+
+    Column(
+        modifier = Modifier
+            .border(width = 2.dp, color = MaterialTheme.colorScheme.secondary)
+            .padding(vertical = 2.5.dp, horizontal = 6.dp)
+            .fillMaxWidth()
+    ) {
         embed.title?.let {
-            Text(it, style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.primary)
-        }
-        embed.description?.let {
-            Text(it.take(120), style = MaterialTheme.typography.bodySmall)
-        }
-        val imgUrl = embed.displayImageUrl
-        if (imgUrl != null) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(imgUrl).crossfade(true).build(),
-                imageLoader = imageLoader,
-                contentDescription = embed.title ?: "embed",
-                contentScale = ContentScale.Fit,
-                modifier = Modifier.widthIn(max = 140.dp).heightIn(max = 140.dp)
+            Text(
+                it,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 3.dp),
+                fontSize = 22.5.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 25.sp
             )
         }
+
+        embed.description?.let {
+            val parsedEmbedDescription = ContentParser.parseMarkdown(embed.description)
+
+            parsedEmbedDescription.forEach { part ->
+                if (part.spoiler) {
+                    SpoilerText(part.text, true)
+                } else {
+                    val annotated = buildAnnotatedString {
+                        val style = SpanStyle(
+                            fontWeight = if (part.bold) androidx.compose.ui.text.font.FontWeight.Bold
+                            else null,
+                            fontStyle = if (part.italic) androidx.compose.ui.text.font.FontStyle.Italic
+                            else null,
+                            textDecoration = when {
+                                part.strikethrough -> TextDecoration.LineThrough
+                                else -> null
+                            },
+                            background = if (part.code) MaterialTheme.colorScheme.surfaceContainer
+                            else androidx.compose.ui.graphics.Color.Unspecified,
+                            fontFamily = if (part.code) androidx.compose.ui.text.font.FontFamily.Monospace
+                            else null
+                        )
+                        withStyle(style) { append(part.text) }
+                    }
+                    Text(text = annotated, style = MaterialTheme.typography.bodySmall)
+
+                }
+            }
+        }
+    }
+    val imgUrl = embed.displayImageUrl
+    if (imgUrl != null) {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current).data(imgUrl).crossfade(true)
+                .build(),
+            imageLoader = imageLoader,
+            contentDescription = embed.title ?: "embed",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .widthIn(max = 140.dp)
+                .heightIn(max = 140.dp)
+                .padding(top = 5.dp)
+        )
     }
 }
 
@@ -1522,18 +1653,15 @@ private fun VideoAttachment(att: Attachment, imageLoader: ImageLoader) {
             .heightIn(max = 100.dp)
             .clickable {
                 runCatching {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(att.url))
-                        .setDataAndType(Uri.parse(att.url), att.contentType ?: "video/*")
+                    val intent = Intent(
+                        Intent.ACTION_VIEW, Uri.parse(att.url)
+                    ).setDataAndType(Uri.parse(att.url), att.contentType ?: "video/*")
                         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     context.startActivity(intent)
                 }
-            }
-    ) {
+            }) {
         AsyncImage(
-            model = ImageRequest.Builder(context)
-                .data(att.proxyUrl)
-                .crossfade(true)
-                .build(),
+            model = ImageRequest.Builder(context).data(att.proxyUrl).crossfade(true).build(),
             imageLoader = imageLoader,
             contentDescription = att.filename,
             contentScale = ContentScale.Fit,
@@ -1595,15 +1723,14 @@ private fun AudioAttachment(att: Attachment) {
             modifier = Modifier
                 .fillMaxWidth()
                 .background(
-                    MaterialTheme.colorScheme.surfaceContainer,
-                    RoundedCornerShape(8.dp)
+                    MaterialTheme.colorScheme.surfaceContainer, RoundedCornerShape(8.dp)
                 )
                 .padding(horizontal = 8.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             Icon(
-                painter= painterResource(id = if (isPlaying) R.drawable.pause else R.drawable.play),
+                painter = painterResource(id = if (isPlaying) R.drawable.pause else R.drawable.play),
                 contentDescription = if (isPlaying) "Pause" else "Play",
                 tint = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier
@@ -1627,8 +1754,7 @@ private fun AudioAttachment(att: Attachment) {
                                 isPlaying = true
                             }
                         }
-                    }
-            )
+                    })
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = att.filename,
@@ -1637,8 +1763,9 @@ private fun AudioAttachment(att: Attachment) {
                     maxLines = 1
                 )
                 LinearProgressIndicator(
-                    progress = { progress },
-                    modifier = Modifier.fillMaxWidth().height(3.dp)
+                    progress = { progress }, modifier = Modifier
+                        .fillMaxWidth()
+                        .height(3.dp)
                 )
             }
         }
@@ -1647,22 +1774,28 @@ private fun AudioAttachment(att: Attachment) {
 
 
 @Composable
-private fun DiscordAvatarWithDecoration(user: com.zaffox.discordwear.api.DiscordUser, imageLoader: ImageLoader, size: Dp, onClick: () -> Unit = {}) {
+private fun DiscordAvatarWithDecoration(
+    user: com.zaffox.discordwear.api.DiscordUser,
+    imageLoader: ImageLoader,
+    size: Dp,
+    onClick: () -> Unit = {}
+) {
     val decorUrl = user.avatarDecorationUrl()
     Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .pointerInput(onClick) {
-                detectTapGestures(
-                    onTap = { onClick() }
-                )
-            }
-    ) {
-        DiscordAvatar(url = user.avatarUrl(32), displayName = user.displayName, imageLoader = imageLoader, size = size)
+        contentAlignment = Alignment.Center, modifier = Modifier.pointerInput(onClick) {
+            detectTapGestures(
+                onTap = { onClick() })
+        }) {
+        DiscordAvatar(
+            url = user.avatarUrl(32),
+            displayName = user.displayName,
+            imageLoader = imageLoader,
+            size = size
+        )
         if (decorUrl != null) {
             AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(decorUrl).crossfade(false).build(),
+                model = ImageRequest.Builder(LocalContext.current).data(decorUrl).crossfade(false)
+                    .build(),
                 imageLoader = imageLoader,
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
@@ -1693,14 +1826,13 @@ private fun DiscordAvatar(url: String?, displayName: String, imageLoader: ImageL
         }
     } else {
         SubcomposeAsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(url)
-                .crossfade(true)
-                .build(),
+            model = ImageRequest.Builder(LocalContext.current).data(url).crossfade(true).build(),
             imageLoader = imageLoader,
             contentDescription = null,
             contentScale = ContentScale.Crop,
-            modifier =Modifier.size(size).clip(CircleShape),
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape),
             error = {
                 Box(
                     modifier = Modifier
@@ -1715,7 +1847,6 @@ private fun DiscordAvatar(url: String?, displayName: String, imageLoader: ImageL
                         fontSize = (size.value * 0.45f).sp
                     )
                 }
-            }
-        )
+            })
     }
 }


### PR DESCRIPTION
List of changes I have made:

- Images and Videos can now be viewed on the browser (images can be zoomed, videos can play) 
(**Tested on Samsung Internet**)
- Added a button to append `||` to your input text
- `-#` (subtext) display support added
- Components have a border around them for easier visibility

The browser changes were only tested on 1 specific browser, and might not work on other WearOS browsers (if there are any)